### PR TITLE
update readme the default download path should be /opt/work/store

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ http://blog.auska.win
 
 ```
 docker create --name=rrshareweb \
--v <path to downloads>:/mnt \
+-v <path to downloads>:/opt/work/store \
 -v <path to rrshare>:/rrshare \
 -e PGID=<gid> -e PUID=<uid> \
 -e TZ=<timezone> \


### PR DESCRIPTION
update the default download path. If we mount to the wrong path like `/mnt` the download will not work, because the `/opt/work/store` path does exist.